### PR TITLE
feat(docker): Auto-fill database config from environment variables

### DIFF
--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -22,14 +22,18 @@ This Docker Compose setup allows you to run TravianZ without installing PHP, MyS
 
 3. **Configure the installation:**
 
-   When you reach the database configuration step, use these settings:
-   - **Hostname:** `db`
-   - **Port:** `3306`
+   When you reach the database configuration step, the form will be **automatically pre-filled** with the correct Docker values:
+   - **Hostname:** `db` (Docker service name)
+   - **Port:** `3306` (internal MySQL port)
    - **Username:** `travianz`
    - **Password:** `travianz_pass`
    - **Database name:** `travianz`
    - **Prefix:** `s1_` (or your choice)
    - **Type:** MYSQLi
+
+   You can simply accept these defaults and continue with the installation.
+
+   **Note:** Port `3307` is for accessing the database from your host machine (outside Docker), but the web container uses the internal port `3306`.
 
    For the server URL settings:
    - **Server:** `http://localhost:8081/`

--- a/install/templates/config.tpl
+++ b/install/templates/config.tpl
@@ -416,23 +416,23 @@ echo "<div class=\"headline\"><span class=\"f10 c5\">Error creating constant.php
     <table>
         <tr>
             <td><span class="f9 c6">Hostname:</span></td>
-            <td><input name="sserver" type="text" id="sserver" value="localhost"></td>
+            <td><input name="sserver" type="text" id="sserver" value="<?php echo getenv('DB_HOST') ?: 'localhost'; ?>"></td>
         </tr>
         <tr>
             <td><span class="f9 c6">Port:</span></td>
-            <td><input name="sport" type="text" id="sport" value="3306"></td>
+            <td><input name="sport" type="text" id="sport" value="<?php echo getenv('DB_PORT') ?: '3306'; ?>"></td>
         </tr>
         <tr>
             <td><span class="f9 c6">Username:</span></td>
-            <td><input name="suser" type="text" id="suser" value=""></td>
+            <td><input name="suser" type="text" id="suser" value="<?php echo getenv('DB_USER') ?: ''; ?>"></td>
         </tr>
         <tr>
             <td><span class="f9 c6">Password:</span></td>
-            <td><input type="password" name="spass" id="spass"></td>
+            <td><input type="password" name="spass" id="spass" value="<?php echo getenv('DB_PASSWORD') ?: ''; ?>"></td>
         </tr>
         <tr>
             <td><span class="f9 c6">DB name:</span></td>
-            <td><input type="text" name="sdb" id="sdb"></td>
+            <td><input type="text" name="sdb" id="sdb" value="<?php echo getenv('DB_NAME') ?: ''; ?>"></td>
         </tr>
         <tr>
             <td><span class="f9 c6">Prefix:</span></td>


### PR DESCRIPTION
## Summary

This PR updates the Docker installer to automatically pre-fill database configuration fields using environment variables from `docker-compose.yml`, eliminating the need for manual entry and preventing common configuration errors.

## Changes

- **Modified `install/templates/config.tpl`**: Updated form fields to read from environment variables:
  - `DB_HOST` → hostname field (defaults to `db` in Docker, `localhost` otherwise)
  - `DB_PORT` → port field (defaults to `3306`)
  - `DB_USER` → username field
  - `DB_PASSWORD` → password field
  - `DB_NAME` → database name field

- **Updated `DOCKER_SETUP.md`**: Revised documentation to reflect that database fields are now automatically pre-filled

## Benefits

1. **Improved UX**: Users no longer need to manually type database credentials during installation
2. **Prevents Errors**: Eliminates the common mistake of using `localhost` instead of `db` in Docker environments
3. **Backward Compatible**: Falls back to standard defaults when environment variables are not set (non-Docker installations still work)

## Testing

Verified that:
- ✅ Form fields are correctly pre-filled with Docker environment variables
- ✅ All database credentials match the values in `docker-compose.yml`
- ✅ Installation proceeds without connection errors

## Screenshots

Database configuration form now shows:
- Hostname: `db`
- Port: `3306`
- Username: `travianz`
- Password: `travianz_pass`
- Database: `travianz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)